### PR TITLE
simplify UI and some fixes

### DIFF
--- a/res1d_loader/res1d_loader_dialog.py
+++ b/res1d_loader/res1d_loader_dialog.py
@@ -326,12 +326,12 @@ class Res1dLoader(QObject):
                 node = self.main_nodes[i]
                 data_items = list(node.DataItems)
                 for data_item in data_items:
-                    if data_item.NumberOfTimeSteps != len(time_steps):
+                    if data_item.NumberOfTimeSteps != len(self.res_1D.data.TimesList):
                         continue
                     if data_item.Quantity.Id != quantity:
                         continue
-                    values_for_time_step = [None]*len(time_index_list)
-                    for t in range(0, len(time_steps)):
+                    values_for_time_step = [None]*len(self.res_1D.data.TimesList)
+                    for t in range(0, len(self.res_1D.data.TimesList)):
                         values = to_numpy(data_item.TimeData.GetValues(t))
                         if len(values) < 1:
                             continue

--- a/res1d_loader/res1d_loader_dialog.py
+++ b/res1d_loader/res1d_loader_dialog.py
@@ -366,7 +366,7 @@ class Res1dLoader(QObject):
                 value_str = [None] * len(self.vertices)
 
                 for n in range(0, len(self.vertices)):
-                    if data[t, n] == 0:
+                    if data[t, n] == delete_value:
                         value_str[n] = '*'
                     else:
                         value_str[n] = str(data[t, n])

--- a/res1d_loader/res1d_loader_dialog.py
+++ b/res1d_loader/res1d_loader_dialog.py
@@ -13,6 +13,7 @@
 import os
 import numpy as np
 import math
+import ntpath
 
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import *
@@ -461,7 +462,7 @@ class Res1dLoader(QObject):
 
             self.update_progress(i,  len(self.dhi_reaches), 100)
 
-        self.layer = QgsMeshLayer(uri_str, "mesh1D", 'mesh_memory')
+        self.layer = QgsMeshLayer(uri_str, ntpath.basename(self.file_name), 'mesh_memory')
 
         self.load_dataset_group()
         self.finished.emit()

--- a/res1d_loader/res1d_loader_dialog.py
+++ b/res1d_loader/res1d_loader_dialog.py
@@ -138,8 +138,8 @@ class Res1dLoader(QObject):
         self.reach_quantities = []
         self.edge_count = 0
 
-        self.vertex_on_grid = False
-        self.vertex_on_digi = False
+        self.vertex_on_grid = True
+        self.vertex_on_digi = True
         self.dataset_on_edge_if_on_vertex = False
 
     def create_mesh(self):
@@ -507,8 +507,7 @@ class Res1DDialog(QDialog, Res1DLoaderDialogUi):
         self.file_widget.fileChanged.connect(self.parseFile)
         self.button_box.accepted.connect(self.launch_loader)
         self.button_box.rejected.connect(self.reject)
-        self.checkBox_on_grid_points.clicked.connect(self.pre_build_mesh)
-        self.checkBox_on_digi_points.clicked.connect(self.pre_build_mesh)
+
         self.time_steps = []
 
         self.start_dateTime_edit.dateTimeChanged.connect(self.update_time_steps_count)
@@ -527,8 +526,6 @@ class Res1DDialog(QDialog, Res1DLoaderDialogUi):
         self.loader.finished.connect(self.loading_thread.quit)
         self.loader.progressChanged.connect(self.progress_dialog.set_progress)
         self.loader.taskChanged.connect(self.progress_dialog.set_task)
-
-        self.checkBox_on_digi_points.setChecked(True)
 
     def parseFile(self, file_name):
 
@@ -587,9 +584,6 @@ class Res1DDialog(QDialog, Res1DLoaderDialogUi):
 
     def pre_build_mesh(self):
 
-        self.loader.vertex_on_grid = self.checkBox_on_grid_points.isChecked()
-        self.loader.vertex_on_digi = self.checkBox_on_digi_points.isChecked()
-
         self.loader.file_name = self.file_widget.filePath()
         self.loader.create_mesh()
 
@@ -603,7 +597,6 @@ class Res1DDialog(QDialog, Res1DLoaderDialogUi):
             return
 
         self.loader.file_name = self.file_widget.filePath()
-        self.loader.dataset_on_edge_if_on_vertex = self.check_box_dataset_on_edge.isChecked()
         self.loader.keep_time_step=self.spin_box_keep_time_step.value()
         self.loader.start_date_time = self.start_dateTime_edit.dateTime()
         self.loader.end_date_time = self.end_dateTime_edit.dateTime()

--- a/res1d_loader/res1d_loader_dialog_base.ui
+++ b/res1d_loader/res1d_loader_dialog_base.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>526</width>
-    <height>290</height>
+    <width>518</width>
+    <height>244</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -55,39 +55,8 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <item row="1" column="5">
-         <widget class="QLabel" name="label_9">
-          <property name="text">
-           <string>Time steps count</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0" colspan="2">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Keep every</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <widget class="QLabel" name="label_8">
-          <property name="text">
-           <string>time steps</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Start time</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="2">
          <widget class="QDateTimeEdit" name="start_dateTime_edit"/>
-        </item>
-        <item row="0" column="6">
-         <widget class="QDateTimeEdit" name="end_dateTime_edit"/>
         </item>
         <item row="0" column="3">
          <spacer name="horizontalSpacer">
@@ -102,12 +71,22 @@
           </property>
          </spacer>
         </item>
-        <item row="2" column="0" colspan="4">
-         <widget class="QCheckBox" name="check_box_dataset_on_edge">
+        <item row="1" column="0" colspan="2">
+         <widget class="QLabel" name="label_7">
           <property name="text">
-           <string>Load dataset group on edge even if presents on vertex</string>
+           <string>Keep every</string>
           </property>
          </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Start time</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="6">
+         <widget class="QDateTimeEdit" name="end_dateTime_edit"/>
         </item>
         <item row="1" column="2">
          <widget class="QgsSpinBox" name="spin_box_keep_time_step">
@@ -123,6 +102,20 @@
          <widget class="QLabel" name="label_5">
           <property name="text">
            <string>End time</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="5">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Time steps count</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>time steps</string>
           </property>
          </widget>
         </item>
@@ -184,45 +177,31 @@
         <string>Mesh</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_3">
-        <item row="1" column="2">
+        <item row="0" column="2">
          <widget class="QLabel" name="label_12">
           <property name="text">
            <string>Edges count</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="3">
-         <widget class="QLabel" name="edges_count_label">
-          <property name="text">
-           <string>-</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLabel" name="vertices_count_label">
-          <property name="text">
-           <string>-</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
+        <item row="0" column="0">
          <widget class="QLabel" name="label_11">
           <property name="text">
            <string>Vertices count</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="0" colspan="2">
-         <widget class="QCheckBox" name="checkBox_on_digi_points">
+        <item row="0" column="1">
+         <widget class="QLabel" name="vertices_count_label">
           <property name="text">
-           <string>Vertices on digi points (geographical points)</string>
+           <string>-</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="2" colspan="2">
-         <widget class="QCheckBox" name="checkBox_on_grid_points">
+        <item row="0" column="3">
+         <widget class="QLabel" name="edges_count_label">
           <property name="text">
-           <string>Vertices on H grid points (calculation points)</string>
+           <string>-</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Simplify the UI by removing choice of having vertices on grid points or/and on digi points.

Also some fixes:
- in some case, in the file, there is an offset between the cartographic chainage of digi points (distance in the reach) and the chainage of grid points. That leads to bad implementation of vertices of the 1D mesh. This PR fix this issue by correcting the calculated chainage of the digi points.

- value on extremity of reaches was always 0 when time steps are skipped, this PR fixes this issue

- no value interpreted as 0 on vertices.